### PR TITLE
feat: add cross-platform background service support

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,23 @@ Download the Windows installer for your architecture from the [releases page](ht
 > [!TIP]
 > To override the default port before installation, set a user environment variable named BACKREST_PORT. On Windows 10+, navigate to Settings > About > Advanced system settings > Environment Variables. Under "User variables", create a new variable `BACKREST_PORT` with the value "127.0.0.1:port" (e.g., "127.0.0.1:8080" for port 8080). If changing post-installation, re-run the installer to update shortcuts with the new port.
 
+### Background service (Windows & Linux)
+
+Backrest ships with a built-in service manager that can install, start, and stop the application as a background service on Windows and Linux. Use the `--service` flag to control the lifecycle:
+
+```sh
+# Install the service and configure the bind address
+backrest --service install --service-arg=--bind-address=127.0.0.1:9897
+
+# Start, stop, or remove the service
+backrest --service start
+backrest --service stop
+backrest --service uninstall
+```
+
+> [!TIP]
+> On Linux, specify an alternate account for the service with `--service-user=<username>`. Repeat `--service-arg` to forward additional Backrest flags such as `--data-dir` or `--config-file`.
+
 # Configuration
 
 ## Environment Variables (Unix)

--- a/build/windows/installer.iss
+++ b/build/windows/installer.iss
@@ -83,8 +83,11 @@ PrivilegesRequiredOverrideAllUsers=Install &system-wide with administrative priv
 ; Use Task Scheduler to run Backrest elevated. The 30s delay is needed to avoid an issue with tray icon being broken.
 ; The double-quotes escape double-quotes inside the parameter. The backslash escapes double-quotes inside the -Command block.
 Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -Command ""$t = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME ; $t.Delay = 'PT30S'; $s = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries; $s.ExecutionTimeLimit = 'PT0S'; Register-ScheduledTask -Force -TaskName '{#B}' -RunLevel Highest -Trigger $t -Action $(New-ScheduledTaskAction -Execute \""{app}\backrest.exe\"" -Argument '--windows-tray --bind-address 127.0.0.1:9897' -WorkingDirectory '{app}') -Settings $s ; Start-ScheduledTask -TaskName '{#B}'"" "; Flags: runascurrentuser logoutput runhidden; Tasks: adminstartcurrent; Check: IsAdminInstallMode
-; System user task. No need for systray here, and running it without returning control is the only way to stop it gracefully later.
-Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -Command ""$s = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries; $s.ExecutionTimeLimit = 'PT0S'; Register-ScheduledTask -Force -TaskName '{#B}' -RunLevel Highest -User System -Trigger $(New-ScheduledTaskTrigger -AtStartup) -Action $(New-ScheduledTaskAction -Execute \""{app}\backrest.exe\"" -Argument '--bind-address 127.0.0.1:9897' -WorkingDirectory '{app}') -Settings $s ; Start-ScheduledTask -TaskName '{#B}'"" "; Flags: runascurrentuser logoutput runhidden; Tasks: adminstartsystem; Check: IsAdminInstallMode
+; Install or update the background service for system-wide runs.
+Filename: "{app}\backrest.exe"; Parameters: "--service install --service-arg=--bind-address=127.0.0.1:9897"; Flags: logoutput runhidden; Tasks: adminstartsystem; Check: IsAdminInstallMode
+Filename: "{app}\backrest.exe"; Parameters: "--service start"; Flags: logoutput runhidden; Tasks: adminstartsystem; Check: IsAdminInstallMode
+Filename: "{app}\backrest.exe"; Parameters: "--service stop"; Flags: logoutput runhidden; Tasks: not adminstartsystem; Check: IsAdminInstallMode
+Filename: "{app}\backrest.exe"; Parameters: "--service uninstall"; Flags: logoutput runhidden; Tasks: not adminstartsystem; Check: IsAdminInstallMode
 ; PATH
 Filename: "powershell.exe"; Parameters: "-ExecutionPolicy Bypass -Command ""$newp = '{app}'; $a = [Environment]::GetEnvironmentVariable('PATH', '{code:GetEnvTarget}') -split ';' ; if ($a -notcontains $newp) {{ echo 'Adding to PATH'; $a += $newp; $path = $a -join ';' ; [Environment]::SetEnvironmentVariable('PATH', $path, '{code:GetEnvTarget}') }"" "; Flags: logoutput runhidden; Tasks: addtopath
 ; Remove from PATH for existing installation when unchecked.
@@ -193,6 +196,13 @@ begin
     // Remove the task when uninstalling.
     if IsUninstaller then
       ExecAndLogOutput(Cmd, '/C schtasks /Delete /TN ' + AppName + ' /F', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, nil);
+  end;
+
+  if IsAdminInstallMode and FileExists(ExpandConstant('{app}\backrest.exe')) then
+  begin
+    ExecAndLogOutput(ExpandConstant('{app}\backrest.exe'), '--service stop', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, nil);
+    if IsUninstaller then
+      ExecAndLogOutput(ExpandConstant('{app}\backrest.exe'), '--service uninstall', '', SW_HIDE, ewWaitUntilTerminated, ResultCode, nil);
   end;
 end;
 

--- a/cmd/backrest/backrest.go
+++ b/cmd/backrest/backrest.go
@@ -45,6 +45,10 @@ var (
 )
 
 func runApp() {
+	runAppWithContext(context.Background(), true)
+}
+
+func runAppWithContext(parent context.Context, handleSignals bool) {
 	installLoggers()
 
 	resticPath, err := resticinstaller.FindOrInstallResticBinary()
@@ -57,9 +61,12 @@ func runApp() {
 		return
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	go onterm(os.Interrupt, cancel)
-	go onterm(os.Interrupt, newForceKillHandler())
+	ctx, cancel := context.WithCancel(parent)
+	defer cancel()
+	if handleSignals {
+		go onterm(os.Interrupt, cancel)
+		go onterm(os.Interrupt, newForceKillHandler())
+	}
 
 	// Load the configuration
 	configMgr := &config.ConfigManager{Store: createConfigProvider()}

--- a/cmd/backrest/main_other.go
+++ b/cmd/backrest/main_other.go
@@ -6,5 +6,8 @@ import "flag"
 
 func main() {
 	flag.Parse()
+	if handleServiceCommand() {
+		return
+	}
 	runApp()
 }

--- a/cmd/backrest/main_windows.go
+++ b/cmd/backrest/main_windows.go
@@ -24,6 +24,9 @@ var windowsTray = flag.Bool("windows-tray", false, "run the windows tray applica
 
 func main() {
 	flag.Parse()
+	if handleServiceCommand() {
+		return
+	}
 	if *windowsTray {
 		startTray()
 	} else {

--- a/cmd/backrest/service.go
+++ b/cmd/backrest/service.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/kardianos/service"
+)
+
+var (
+	serviceCommand = flag.String("service", "", "manage the backrest background service (install, uninstall, start, stop, restart, run)")
+	serviceUser    = flag.String("service-user", "", "user account to run the service as (platform dependent)")
+	serviceArgs    []string
+)
+
+func init() {
+	flag.Func("service-arg", "additional argument to pass to the backrest service when it runs (repeatable)", func(value string) error {
+		if value == "" {
+			return errors.New("service-arg cannot be empty")
+		}
+		serviceArgs = append(serviceArgs, value)
+		return nil
+	})
+}
+
+func handleServiceCommand() bool {
+	if *serviceCommand == "" {
+		return false
+	}
+
+	cfg := &service.Config{
+		Name:        "backrest",
+		DisplayName: "Backrest",
+		Description: "Backrest backup orchestrator",
+		Arguments:   append([]string{"--service", "run"}, serviceArgs...),
+	}
+
+	if *serviceUser != "" {
+		cfg.UserName = *serviceUser
+	}
+
+	if runtime.GOOS == "linux" {
+		cfg.Option = service.KeyValue{
+			"Restart":           "on-failure",
+			"RestartSec":        "5",
+			"SuccessExitStatus": "0 2",
+		}
+	}
+
+	svc, err := service.New(newBackrestService(), cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to configure service: %v\n", err)
+		os.Exit(1)
+	}
+
+	switch *serviceCommand {
+	case "install":
+		err = svc.Install()
+	case "uninstall":
+		err = svc.Uninstall()
+	case "start":
+		err = svc.Start()
+	case "stop":
+		err = svc.Stop()
+	case "restart":
+		err = svc.Restart()
+	case "run":
+		err = svc.Run()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown service command %q\n", *serviceCommand)
+		os.Exit(1)
+	}
+
+	if err != nil {
+		if errors.Is(err, service.ErrNotInstalled) && (*serviceCommand == "stop" || *serviceCommand == "uninstall") {
+			err = nil
+		}
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "service command %q failed: %v\n", *serviceCommand, err)
+		os.Exit(1)
+	}
+
+	return true
+}
+
+type backrestService struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func newBackrestService() *backrestService {
+	return &backrestService{}
+}
+
+func (s *backrestService) Start(_ service.Service) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	s.done = make(chan struct{})
+	go func() {
+		defer close(s.done)
+		runAppWithContext(ctx, false)
+	}()
+	return nil
+}
+
+func (s *backrestService) Stop(_ service.Service) error {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.done != nil {
+		<-s.done
+	}
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hectane/go-acl v0.0.0-20230122075934-ca0b05cb1adb
+	github.com/kardianos/service v1.2.2
 	github.com/mattn/go-colorable v0.1.14
 	github.com/natefinch/atomic v1.0.1
 	github.com/ncruces/go-sqlite3 v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nu
 github.com/jarcoal/httpmock v1.3.0/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/josephspurrier/goversioninfo v1.5.0 h1:9TJtORoyf4YMoWSOo/cXFN9A/lB3PniJ91OxIH6e7Zg=
 github.com/josephspurrier/goversioninfo v1.5.0/go.mod h1:6MoTvFZ6GKJkzcdLnU5T/RGYUbHQbKpYeNP0AgQLd2o=
+github.com/kardianos/service v1.2.2 h1:ZvePhAHfvo0A7Mftk/tEzqEZ7Q4lgnR8sGz4xu1YX60=
+github.com/kardianos/service v1.2.2/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -191,6 +193,7 @@ golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190529164535-6a60838ec259/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
## Summary
- add cross-platform service management flags so Backrest can run as a background service on Windows and Linux
- integrate the new service commands with the Windows installer and ensure upgrades stop and remove existing services
- document the service workflow and add the kardianos/service dependency

## Testing
- go test ./... *(fails: webui/webuinix.go:14:12: pattern dist: no matching files found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc49ff0cf4832e96915bdbbda695a1